### PR TITLE
Only log the SNS response if it's unsuccessful

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,4 +1,4 @@
-RELEASE_TYPE: minor
+RELEASE_TYPE: patch
 
 Previously sending a message with ``sns_utils.publish_sns_message`` would
 log the entire SNS response.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+Previously sending a message with ``sns_utils.publish_sns_message`` would
+log the entire SNS response.
+
+Now the response is only logged if the SNS message is unsuccessful.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -86,6 +86,10 @@ ECS
 .. raw:: html
 
     <span id="ecs"></span>
+    <dl class="exception">
+    <dt id="wellcome_aws_utils.ecs_utils.EcsThrottleException">
+    <em class="property">exception </em><code class="descclassname">wellcome_aws_utils.ecs_utils.</code><code class="descname">EcsThrottleException</code><a class="reference internal" href="_modules/wellcome_aws_utils/ecs_utils.html#EcsThrottleException"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#wellcome_aws_utils.ecs_utils.EcsThrottleException" title="Permalink to this definition">¶</a></dt>
+    <dd></dd></dl>
     <dl class="function">
     <dt id="wellcome_aws_utils.ecs_utils.clone_task_definition">
     <code class="descclassname">wellcome_aws_utils.ecs_utils.</code><code class="descname">clone_task_definition</code><span class="sig-paren">(</span><em>client</em>, <em>task_definition</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/wellcome_aws_utils/ecs_utils.html#clone_task_definition"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#wellcome_aws_utils.ecs_utils.clone_task_definition" title="Permalink to this definition">¶</a></dt>
@@ -214,6 +218,30 @@ SNS
 
     <span id="sns"></span>
     <dl class="class">
+    <dt id="wellcome_aws_utils.sns_utils.EnhancedJSONEncoder">
+    <em class="property">class </em><code class="descclassname">wellcome_aws_utils.sns_utils.</code><code class="descname">EnhancedJSONEncoder</code><span class="sig-paren">(</span><em>*</em>, <em>skipkeys=False</em>, <em>ensure_ascii=True</em>, <em>check_circular=True</em>, <em>allow_nan=True</em>, <em>sort_keys=False</em>, <em>indent=None</em>, <em>separators=None</em>, <em>default=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/wellcome_aws_utils/sns_utils.html#EnhancedJSONEncoder"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#wellcome_aws_utils.sns_utils.EnhancedJSONEncoder" title="Permalink to this definition">¶</a></dt>
+    <dd><dl class="method">
+    <dt id="wellcome_aws_utils.sns_utils.EnhancedJSONEncoder.default">
+    <code class="descname">default</code><span class="sig-paren">(</span><em>obj</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/wellcome_aws_utils/sns_utils.html#EnhancedJSONEncoder.default"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#wellcome_aws_utils.sns_utils.EnhancedJSONEncoder.default" title="Permalink to this definition">¶</a></dt>
+    <dd><p>Implement this method in a subclass such that it returns
+    a serializable object for <code class="docutils literal notranslate"><span class="pre">o</span></code>, or calls the base implementation
+    (to raise a <code class="docutils literal notranslate"><span class="pre">TypeError</span></code>).</p>
+    <p>For example, to support arbitrary iterators, you could
+    implement default like this:</p>
+    <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="k">def</span> <span class="nf">default</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">o</span><span class="p">):</span>
+        <span class="k">try</span><span class="p">:</span>
+            <span class="n">iterable</span> <span class="o">=</span> <span class="nb">iter</span><span class="p">(</span><span class="n">o</span><span class="p">)</span>
+        <span class="k">except</span> <span class="ne">TypeError</span><span class="p">:</span>
+            <span class="k">pass</span>
+        <span class="k">else</span><span class="p">:</span>
+            <span class="k">return</span> <span class="nb">list</span><span class="p">(</span><span class="n">iterable</span><span class="p">)</span>
+        <span class="c1"># Let the base class default method raise the TypeError</span>
+        <span class="k">return</span> <span class="n">JSONEncoder</span><span class="o">.</span><span class="n">default</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">o</span><span class="p">)</span>
+    </pre></div>
+    </div>
+    </dd></dl>
+    </dd></dl>
+    <dl class="class">
     <dt id="wellcome_aws_utils.sns_utils.SNSEvent">
     <em class="property">class </em><code class="descclassname">wellcome_aws_utils.sns_utils.</code><code class="descname">SNSEvent</code><span class="sig-paren">(</span><em>subject</em>, <em>message</em><span class="sig-paren">)</span><a class="headerlink" href="#wellcome_aws_utils.sns_utils.SNSEvent" title="Permalink to this definition">¶</a></dt>
     <dd><dl class="attribute">
@@ -264,7 +292,7 @@ SQS
     <dl class="function">
     <dt id="wellcome_aws_utils.sqs_utils.get_messages">
     <code class="descclassname">wellcome_aws_utils.sqs_utils.</code><code class="descname">get_messages</code><span class="sig-paren">(</span><em>queue_url</em>, <em>delete=False</em>, <em>batch_size=10</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/wellcome_aws_utils/sqs_utils.html#get_messages"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#wellcome_aws_utils.sqs_utils.get_messages" title="Permalink to this definition">¶</a></dt>
-    <dd><p>Gets messages from an SQS queue.  If <code class="docutils literal"><span class="pre">delete</span></code> is True, the
+    <dd><p>Gets messages from an SQS queue.  If <code class="docutils literal notranslate"><span class="pre">delete</span></code> is True, the
     messages are also deleted after they’ve been read.</p>
     </dd></dl>
 

--- a/src/wellcome_aws_utils/sns_utils.py
+++ b/src/wellcome_aws_utils/sns_utils.py
@@ -45,8 +45,11 @@ def publish_sns_message(sns_client,
         Subject=subject
     )
 
-    print(f'SNS response = {response!r}')
-    assert response['ResponseMetadata']['HTTPStatusCode'] == 200
+    if response['ResponseMetadata']['HTTPStatusCode'] == 200:
+        print(f'SNS: sent notification {response["MessageId"]}')
+    else:
+        print(f'SNS: unexpected error = {response!r}')
+        raise RuntimeError
 
     return response
 


### PR DESCRIPTION
Another small patch that should reduce the amount of logging by our Lambdas.

An SNS response is ~400 bytes. We send many SNS messages from the S3 demultiplexers!