### PR TITLE
Fix to fetch dynamo record from reporting

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+The adapters now only send an ID / Version, and we need to look that up in Dynamo to fetch the S3 object in the reporting code.


### PR DESCRIPTION
The adapters now only send an ID / Version, and we need to look that up in Dynamo to fetch the S3 object in the reporting code.